### PR TITLE
feat: implement lead management platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+**/bin/
+**/obj/
+backend/LeadManager.Api/notifications/
+*.user
+*.suo
+.vs/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,73 @@
-# Bebidas Delivery
+# Lead Manager
 
-Esta é uma aplicação simples inspirada no iFood focada em pedidos de bebidas. O projeto demonstra uma interface básica de listagem de bebidas e um carrinho de compras implementado apenas com HTML, CSS e JavaScript.
+Aplicação de gerenciamento de leads composta por uma API .NET 6 e uma SPA em React.
 
-Para executá-lo basta abrir o arquivo `index.html` em um navegador.
+## Estrutura do projeto
+
+```
+backend/
+ ├── LeadManager.sln
+ ├── LeadManager.Api/        # API ASP.NET Core 6
+ └── LeadManager.Tests/      # Testes unitários xUnit
+css/                         # Estilos da SPA
+js/                          # Código React (Babel standalone)
+index.html                   # Ponto de entrada da aplicação
+```
+
+## Pré-requisitos
+
+- [.NET SDK 6.0](https://dotnet.microsoft.com/en-us/download)
+- SQL Server (pode ser LocalDB ou uma instância Docker acessível)
+- Node.js **não** é necessário: a SPA utiliza React via CDN
+
+## Configurando o banco de dados
+
+1. Atualize a connection string em `backend/LeadManager.Api/appsettings.json` caso não utilize `LocalDB`.
+2. Execute as migrações (ou utilize `EnsureCreated`) para criar o schema:
+
+```bash
+cd backend
+ dotnet tool restore
+ dotnet ef database update --project LeadManager.Api/LeadManager.Api.csproj
+```
+
+> O projeto chama `EnsureCreated()` no startup para facilitar os testes locais. Em produção recomenda-se utilizar migrações.
+
+## Executando a API
+
+```bash
+cd backend
+ dotnet restore
+ dotnet run --project LeadManager.Api/LeadManager.Api.csproj
+```
+
+A API será iniciada (por padrão) em `https://localhost:7088` e `http://localhost:5088`.
+
+### Endpoints principais
+
+- `GET /api/leads?status=Invited|Accepted` – lista leads por status
+- `POST /api/leads/{id}/accept` – aceita o lead, aplica desconto de 10% quando `price > 500` e registra notificação
+- `POST /api/leads/{id}/decline` – marca lead como recusado
+
+As notificações de e-mail são simuladas em `./notifications/email-log.txt`.
+
+## Executando os testes unitários
+
+```bash
+cd backend
+ dotnet test
+```
+
+Os testes cobrem a lógica de aceitação/recusa de leads, incluindo a regra de desconto e a chamada do serviço de e-mail.
+
+## Executando a SPA
+
+1. Certifique-se de que a API está em execução em `http://localhost:5088` (ou ajuste a constante `API_BASE_URL` em `js/app.js`).
+2. Abra `index.html` diretamente no navegador ou sirva a pasta via qualquer servidor estático.
+
+A SPA possui duas abas:
+
+- **Invited**: lista os leads novos com ações de *Accept* e *Decline*.
+- **Accepted**: mostra os leads aceitos, incluindo telefone e e-mail de contato.
+
+As ações consomem a API e atualizam as listas em tempo real.

--- a/backend/LeadManager.Api/Controllers/LeadsController.cs
+++ b/backend/LeadManager.Api/Controllers/LeadsController.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using LeadManager.Api.DTOs;
+using LeadManager.Api.Models;
+using LeadManager.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LeadManager.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class LeadsController : ControllerBase
+{
+    private readonly ILeadService _leadService;
+
+    public LeadsController(ILeadService leadService)
+    {
+        _leadService = leadService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<LeadDto>>> GetLeads([FromQuery] LeadStatus? status, CancellationToken cancellationToken)
+    {
+        var resolvedStatus = status ?? LeadStatus.Invited;
+        var leads = await _leadService.GetLeadsAsync(resolvedStatus, cancellationToken);
+        return Ok(leads.Select(LeadDto.FromModel));
+    }
+
+    [HttpPost("{id:int}/accept")]
+    public async Task<ActionResult<LeadDto>> AcceptLead(int id, CancellationToken cancellationToken)
+    {
+        var lead = await _leadService.AcceptLeadAsync(id, cancellationToken);
+
+        if (lead is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(LeadDto.FromModel(lead));
+    }
+
+    [HttpPost("{id:int}/decline")]
+    public async Task<ActionResult<LeadDto>> DeclineLead(int id, CancellationToken cancellationToken)
+    {
+        var lead = await _leadService.DeclineLeadAsync(id, cancellationToken);
+
+        if (lead is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(LeadDto.FromModel(lead));
+    }
+}

--- a/backend/LeadManager.Api/DTOs/LeadDto.cs
+++ b/backend/LeadManager.Api/DTOs/LeadDto.cs
@@ -1,0 +1,38 @@
+using LeadManager.Api.Models;
+
+namespace LeadManager.Api.DTOs;
+
+public record LeadDto(
+    int Id,
+    string ContactFirstName,
+    string ContactLastName,
+    string ContactFullName,
+    string ContactPhoneNumber,
+    string ContactEmail,
+    DateTime CreatedAt,
+    string Suburb,
+    string Category,
+    string Description,
+    decimal Price,
+    LeadStatus Status)
+{
+    public static LeadDto FromModel(Lead lead)
+    {
+        var fullName = string.Join(" ", new[] { lead.ContactFirstName, lead.ContactLastName }
+            .Where(part => !string.IsNullOrWhiteSpace(part)));
+
+        return new LeadDto(
+            lead.Id,
+            lead.ContactFirstName,
+            lead.ContactLastName,
+            fullName,
+            lead.ContactPhoneNumber,
+            lead.ContactEmail,
+            lead.CreatedAt,
+            lead.Suburb,
+            lead.Category,
+            lead.Description,
+            lead.Price,
+            lead.Status);
+    }
+}

--- a/backend/LeadManager.Api/Data/LeadDbContext.cs
+++ b/backend/LeadManager.Api/Data/LeadDbContext.cs
@@ -1,0 +1,67 @@
+using LeadManager.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeadManager.Api.Data;
+
+public class LeadDbContext : DbContext
+{
+    public LeadDbContext(DbContextOptions<LeadDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Lead> Leads => Set<Lead>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Lead>()
+            .Property(lead => lead.Price)
+            .HasColumnType("decimal(18,2)");
+
+        modelBuilder.Entity<Lead>().HasData(
+            new Lead
+            {
+                Id = 1,
+                ContactFirstName = "Maria",
+                ContactLastName = "Silva",
+                ContactEmail = "maria.silva@example.com",
+                ContactPhoneNumber = "+55 11 99999-0001",
+                CreatedAt = new DateTime(2024, 1, 12, 10, 30, 0, DateTimeKind.Utc),
+                Suburb = "São Paulo",
+                Category = "Pintura",
+                Description = "Pintura de sala e quarto",
+                Price = 450m,
+                Status = LeadStatus.Invited
+            },
+            new Lead
+            {
+                Id = 2,
+                ContactFirstName = "João",
+                ContactLastName = "Pereira",
+                ContactEmail = "joao.pereira@example.com",
+                ContactPhoneNumber = "+55 21 98888-0002",
+                CreatedAt = new DateTime(2024, 1, 18, 9, 0, 0, DateTimeKind.Utc),
+                Suburb = "Rio de Janeiro",
+                Category = "Eletricista",
+                Description = "Instalação de luminárias",
+                Price = 620m,
+                Status = LeadStatus.Invited
+            },
+            new Lead
+            {
+                Id = 3,
+                ContactFirstName = "Ana",
+                ContactLastName = "Souza",
+                ContactEmail = "ana.souza@example.com",
+                ContactPhoneNumber = "+55 31 97777-0003",
+                CreatedAt = new DateTime(2024, 1, 5, 15, 45, 0, DateTimeKind.Utc),
+                Suburb = "Belo Horizonte",
+                Category = "Jardinagem",
+                Description = "Manutenção de jardim",
+                Price = 300m,
+                Status = LeadStatus.Accepted
+            }
+        );
+    }
+}

--- a/backend/LeadManager.Api/LeadManager.Api.csproj
+++ b/backend/LeadManager.Api/LeadManager.Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.28" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.28" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.28" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/backend/LeadManager.Api/Models/Lead.cs
+++ b/backend/LeadManager.Api/Models/Lead.cs
@@ -1,0 +1,16 @@
+namespace LeadManager.Api.Models;
+
+public class Lead
+{
+    public int Id { get; set; }
+    public string ContactFirstName { get; set; } = string.Empty;
+    public string ContactLastName { get; set; } = string.Empty;
+    public string ContactPhoneNumber { get; set; } = string.Empty;
+    public string ContactEmail { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public string Suburb { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public LeadStatus Status { get; set; } = LeadStatus.Invited;
+}

--- a/backend/LeadManager.Api/Models/LeadStatus.cs
+++ b/backend/LeadManager.Api/Models/LeadStatus.cs
@@ -1,0 +1,8 @@
+namespace LeadManager.Api.Models;
+
+public enum LeadStatus
+{
+    Invited = 0,
+    Accepted = 1,
+    Declined = 2
+}

--- a/backend/LeadManager.Api/Program.cs
+++ b/backend/LeadManager.Api/Program.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+using LeadManager.Api.Data;
+using LeadManager.Api.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+builder.Services.AddDbContext<LeadDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped<ILeadService, LeadService>();
+builder.Services.AddSingleton<IEmailService, FakeEmailService>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("SpaClient", policy =>
+    {
+        policy.WithOrigins(builder.Configuration.GetSection("SpaClients").Get<string[]>() ??
+                            new[] { "http://localhost:3000", "http://localhost:5173" })
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<LeadDbContext>();
+    db.Database.EnsureCreated();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseCors("SpaClient");
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/backend/LeadManager.Api/Services/FakeEmailService.cs
+++ b/backend/LeadManager.Api/Services/FakeEmailService.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using System.IO;
+using LeadManager.Api.Models;
+
+namespace LeadManager.Api.Services;
+
+public class FakeEmailService : IEmailService
+{
+    private const string Recipient = "sales@test.com";
+
+    public async Task SendLeadAcceptedNotificationAsync(Lead lead, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "notifications");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "email-log.txt");
+
+        var message = $"[{DateTime.UtcNow:O}] To: {Recipient} | Lead: {lead.Id} | Price: {lead.Price.ToString("C", CultureInfo.InvariantCulture)}{Environment.NewLine}";
+
+        await File.AppendAllTextAsync(filePath, message, cancellationToken);
+    }
+}

--- a/backend/LeadManager.Api/Services/IEmailService.cs
+++ b/backend/LeadManager.Api/Services/IEmailService.cs
@@ -1,0 +1,8 @@
+using LeadManager.Api.Models;
+
+namespace LeadManager.Api.Services;
+
+public interface IEmailService
+{
+    Task SendLeadAcceptedNotificationAsync(Lead lead, CancellationToken cancellationToken = default);
+}

--- a/backend/LeadManager.Api/Services/ILeadService.cs
+++ b/backend/LeadManager.Api/Services/ILeadService.cs
@@ -1,0 +1,10 @@
+using LeadManager.Api.Models;
+
+namespace LeadManager.Api.Services;
+
+public interface ILeadService
+{
+    Task<IReadOnlyCollection<Lead>> GetLeadsAsync(LeadStatus status, CancellationToken cancellationToken = default);
+    Task<Lead?> AcceptLeadAsync(int id, CancellationToken cancellationToken = default);
+    Task<Lead?> DeclineLeadAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/backend/LeadManager.Api/Services/LeadService.cs
+++ b/backend/LeadManager.Api/Services/LeadService.cs
@@ -1,0 +1,71 @@
+using LeadManager.Api.Data;
+using LeadManager.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeadManager.Api.Services;
+
+public class LeadService : ILeadService
+{
+    private readonly LeadDbContext _dbContext;
+    private readonly IEmailService _emailService;
+
+    public LeadService(LeadDbContext dbContext, IEmailService emailService)
+    {
+        _dbContext = dbContext;
+        _emailService = emailService;
+    }
+
+    public async Task<IReadOnlyCollection<Lead>> GetLeadsAsync(LeadStatus status, CancellationToken cancellationToken = default)
+    {
+        var leads = await _dbContext.Leads
+            .AsNoTracking()
+            .Where(lead => lead.Status == status)
+            .OrderByDescending(lead => lead.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        return leads;
+    }
+
+    public async Task<Lead?> AcceptLeadAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var lead = await _dbContext.Leads.FirstOrDefaultAsync(lead => lead.Id == id, cancellationToken);
+
+        if (lead is null)
+        {
+            return null;
+        }
+
+        var wasAlreadyAccepted = lead.Status == LeadStatus.Accepted;
+
+        if (!wasAlreadyAccepted)
+        {
+            lead.Status = LeadStatus.Accepted;
+
+            if (lead.Price > 500m)
+            {
+                lead.Price = Math.Round(lead.Price * 0.9m, 2, MidpointRounding.AwayFromZero);
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await _emailService.SendLeadAcceptedNotificationAsync(lead, cancellationToken);
+        }
+
+        return lead;
+    }
+
+    public async Task<Lead?> DeclineLeadAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var lead = await _dbContext.Leads.FirstOrDefaultAsync(lead => lead.Id == id, cancellationToken);
+
+        if (lead is null)
+        {
+            return null;
+        }
+
+        lead.Status = LeadStatus.Declined;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return lead;
+    }
+}

--- a/backend/LeadManager.Api/appsettings.json
+++ b/backend/LeadManager.Api/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=LeadManagerDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "SpaClients": [
+    "http://localhost:3000",
+    "http://localhost:5173"
+  ]
+}

--- a/backend/LeadManager.Tests/LeadManager.Tests.csproj
+++ b/backend/LeadManager.Tests/LeadManager.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.28" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LeadManager.Api\LeadManager.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/LeadManager.Tests/LeadServiceTests.cs
+++ b/backend/LeadManager.Tests/LeadServiceTests.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Linq;
+using LeadManager.Api.Data;
+using LeadManager.Api.Models;
+using LeadManager.Api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeadManager.Tests;
+
+public class LeadServiceTests
+{
+    [Fact]
+    public async Task AcceptLeadAsync_WithHighPrice_AppliesDiscountAndSendsNotification()
+    {
+        using var context = CreateContext(nameof(AcceptLeadAsync_WithHighPrice_AppliesDiscountAndSendsNotification));
+        context.Leads.Add(new Lead
+        {
+            Id = 1,
+            ContactFirstName = "Test",
+            CreatedAt = DateTime.UtcNow,
+            Suburb = "Cidade",
+            Category = "Teste",
+            Description = "Descrição",
+            Price = 1000m,
+            Status = LeadStatus.Invited
+        });
+        await context.SaveChangesAsync();
+
+        var emailService = new TestEmailService();
+        var service = new LeadService(context, emailService);
+
+        var lead = await service.AcceptLeadAsync(1);
+
+        Assert.NotNull(lead);
+        Assert.Equal(LeadStatus.Accepted, lead!.Status);
+        Assert.Equal(900m, lead.Price);
+        Assert.Single(emailService.SentLeads);
+        Assert.Equal(1, emailService.SentLeads.Single().Id);
+    }
+
+    [Fact]
+    public async Task AcceptLeadAsync_WhenLeadDoesNotExist_ReturnsNull()
+    {
+        using var context = CreateContext(nameof(AcceptLeadAsync_WhenLeadDoesNotExist_ReturnsNull));
+        var emailService = new TestEmailService();
+        var service = new LeadService(context, emailService);
+
+        var lead = await service.AcceptLeadAsync(42);
+
+        Assert.Null(lead);
+        Assert.Empty(emailService.SentLeads);
+    }
+
+    [Fact]
+    public async Task AcceptLeadAsync_WhenLeadIsAlreadyAccepted_DoesNotSendNotificationAgain()
+    {
+        using var context = CreateContext(nameof(AcceptLeadAsync_WhenLeadIsAlreadyAccepted_DoesNotSendNotificationAgain));
+        context.Leads.Add(new Lead
+        {
+            Id = 9,
+            ContactFirstName = "Joana",
+            CreatedAt = DateTime.UtcNow,
+            Suburb = "Cidade",
+            Category = "Teste",
+            Description = "Descrição",
+            Price = 540m,
+            Status = LeadStatus.Accepted
+        });
+        await context.SaveChangesAsync();
+
+        var emailService = new TestEmailService();
+        var service = new LeadService(context, emailService);
+
+        var lead = await service.AcceptLeadAsync(9);
+
+        Assert.NotNull(lead);
+        Assert.Equal(LeadStatus.Accepted, lead!.Status);
+        Assert.Equal(540m, lead.Price);
+        Assert.Empty(emailService.SentLeads);
+    }
+
+    [Fact]
+    public async Task DeclineLeadAsync_UpdatesStatus()
+    {
+        using var context = CreateContext(nameof(DeclineLeadAsync_UpdatesStatus));
+        context.Leads.Add(new Lead
+        {
+            Id = 5,
+            ContactFirstName = "Maria",
+            CreatedAt = DateTime.UtcNow,
+            Suburb = "Cidade",
+            Category = "Teste",
+            Description = "Descrição",
+            Price = 200m,
+            Status = LeadStatus.Invited
+        });
+        await context.SaveChangesAsync();
+
+        var emailService = new TestEmailService();
+        var service = new LeadService(context, emailService);
+
+        var lead = await service.DeclineLeadAsync(5);
+
+        Assert.NotNull(lead);
+        Assert.Equal(LeadStatus.Declined, lead!.Status);
+        Assert.Empty(emailService.SentLeads);
+    }
+
+    private static LeadDbContext CreateContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<LeadDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+
+        return new LeadDbContext(options);
+    }
+
+    private sealed class TestEmailService : IEmailService
+    {
+        public List<Lead> SentLeads { get; } = new();
+
+        public Task SendLeadAcceptedNotificationAsync(Lead lead, CancellationToken cancellationToken = default)
+        {
+            SentLeads.Add(lead);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/backend/LeadManager.sln
+++ b/backend/LeadManager.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33815.320
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeadManager.Api", "LeadManager.Api\\LeadManager.Api.csproj", "{B53E747D-CE35-4837-8CF1-DD09500B7733}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeadManager.Tests", "LeadManager.Tests\\LeadManager.Tests.csproj", "{5214182B-6116-43FE-8F5A-411B43A55EAA}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{B53E747D-CE35-4837-8CF1-DD09500B7733}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B53E747D-CE35-4837-8CF1-DD09500B7733}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B53E747D-CE35-4837-8CF1-DD09500B7733}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B53E747D-CE35-4837-8CF1-DD09500B7733}.Release|Any CPU.Build.0 = Release|Any CPU
+{5214182B-6116-43FE-8F5A-411B43A55EAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{5214182B-6116-43FE-8F5A-411B43A55EAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{5214182B-6116-43FE-8F5A-411B43A55EAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{5214182B-6116-43FE-8F5A-411B43A55EAA}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/css/style.css
+++ b/css/style.css
@@ -1,84 +1,230 @@
+:root {
+  --background: #f5f7fb;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --border: #d0d7e2;
+  --text: #1f2933;
+  --muted: #64748b;
+  --success: #15803d;
+  --danger: #b91c1c;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
   margin: 0;
-  padding: 0;
-  background-color: #f5f5f5;
+  background: var(--background);
+  color: var(--text);
 }
 
 header {
-  background-color: #c62828;
-  color: #fff;
-  padding: 1rem;
-  text-align: center;
+  background: white;
+  border-bottom: 1px solid var(--border);
+  padding: 1.5rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
 .container {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 0 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
 }
 
-.drink {
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.tab-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-button.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.24);
+}
+
+.leads-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.lead-card {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lead-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.lead-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.status-chip {
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+.lead-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.meta-item span {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.description {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.card-footer {
   display: flex;
   align-items: center;
-  background-color: #fff;
-  margin-bottom: 1rem;
-  padding: 1rem;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-
-.drink img {
-  width: 80px;
-  height: 80px;
-  object-fit: cover;
-  margin-right: 1rem;
-}
-
-.drink button {
-  margin-left: auto;
-  background-color: #388e3c;
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  border-radius: 4px;
-}
-
-#cart {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 300px;
-  height: 100%;
-  background-color: #fff;
-  box-shadow: -2px 0 5px rgba(0,0,0,0.1);
-  padding: 1rem;
-  overflow-y: auto;
-}
-
-#cart h2 {
-  margin-top: 0;
-}
-
-#cart ul {
-  list-style: none;
-  padding: 0;
-}
-
-#cart li {
-  display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  gap: 1rem;
 }
 
-.checkout {
-  margin-top: 1rem;
-  background-color: #c62828;
-  color: #fff;
+.price {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.actions button {
+  border-radius: 0.75rem;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
   border: none;
-  padding: 0.5rem 1rem;
-  width: 100%;
   cursor: pointer;
-  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.actions button.accept {
+  background: var(--success);
+  color: white;
+  box-shadow: 0 10px 20px rgba(21, 128, 61, 0.24);
+}
+
+.actions button.decline {
+  background: var(--danger);
+  color: white;
+  box-shadow: 0 10px 20px rgba(185, 28, 28, 0.24);
+}
+
+.actions button:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.empty-state {
+  background: white;
+  border-radius: 1rem;
+  padding: 3rem;
+  text-align: center;
+  border: 2px dashed var(--border);
+  color: var(--muted);
+}
+
+.error-message {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--danger);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(185, 28, 28, 0.2);
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .lead-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .card-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .actions button {
+    flex: 1;
+    justify-content: center;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -1,22 +1,18 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bebidas Delivery</title>
-  <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
-  <header>
-    <h1>Bebidas Delivery</h1>
-  </header>
-  <div class="container"></div>
-  <div id="cart">
-    <h2>Carrinho</h2>
-    <ul id="cart-items"></ul>
-    <p>Total: R$ <span id="total">0.00</span></p>
-    <button class="checkout" onclick="checkout()">Finalizar Pedido</button>
-  </div>
-  <script src="js/app.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lead Manager</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="css/style.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="js/app.js"></script>
+  </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,63 +1,224 @@
-const menu = [
-  { id: 1, name: 'Cerveja Artesanal', price: 12.0 },
-  { id: 2, name: 'Vinho Tinto', price: 45.0 },
-  { id: 3, name: 'Refrigerante', price: 6.0 },
-  { id: 4, name: 'Suco Natural', price: 8.0 }
+const { useEffect, useState } = React;
+
+const API_BASE_URL = window.LEAD_MANAGER_API ?? 'http://localhost:5088/api';
+
+const TABS = [
+  {
+    key: 'Invited',
+    label: 'Invited',
+    description: 'Leads aguardando sua resposta.',
+    icon: 'fa-envelope-open-text'
+  },
+  {
+    key: 'Accepted',
+    label: 'Accepted',
+    description: 'Leads já aceitos pela equipe.',
+    icon: 'fa-circle-check'
+  }
 ];
 
-const cart = [];
+const formatDate = (value) =>
+  new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  }).format(new Date(value));
 
-function renderMenu() {
-  const container = document.querySelector('.container');
-  menu.forEach(drink => {
-    const div = document.createElement('div');
-    div.className = 'drink';
-    div.innerHTML = `
-      <img src="https://source.unsplash.com/80x80/?drink" alt="${drink.name}">
-      <div>
-        <strong>${drink.name}</strong><br>
-        R$ ${drink.price.toFixed(2)}
+const formatPrice = (value) =>
+  new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2
+  }).format(value);
+
+const MetaItem = ({ label, value, icon }) => (
+  <div className="meta-item">
+    <small><i className={`fa-solid ${icon}`} style={{ marginRight: '6px' }} />{label}</small>
+    <span>{value}</span>
+  </div>
+);
+
+const LeadCard = ({ lead, onAccept, onDecline, isProcessing, showActions, isAcceptedTab }) => {
+  const statusChipLabel = lead.status;
+
+  return (
+    <article className="lead-card">
+      <div className="lead-header">
+        <h2>{lead.contactFullName || lead.contactFirstName}</h2>
+        <span className="status-chip">
+          <i className="fa-solid fa-bolt" style={{ marginRight: '6px' }} />
+          {statusChipLabel}
+        </span>
       </div>
-      <button onclick="addToCart(${drink.id})">Adicionar</button>
-    `;
-    container.appendChild(div);
-  });
-}
 
-function addToCart(id) {
-  const drink = menu.find(d => d.id === id);
-  cart.push(drink);
-  renderCart();
-}
+      <div className="lead-meta">
+        <MetaItem label="Criado em" value={formatDate(lead.createdAt)} icon="fa-calendar" />
+        <MetaItem label="Bairro" value={lead.suburb} icon="fa-location-dot" />
+        <MetaItem label="Categoria" value={lead.category} icon="fa-layer-group" />
+        <MetaItem label="ID" value={`#${lead.id}`} icon="fa-hashtag" />
+      </div>
 
-function renderCart() {
-  const list = document.querySelector('#cart-items');
-  list.innerHTML = '';
-  cart.forEach((item, index) => {
-    const li = document.createElement('li');
-    li.innerHTML = `${item.name} - R$ ${item.price.toFixed(2)} <button onclick="removeFromCart(${index})">X</button>`;
-    list.appendChild(li);
-  });
-  const total = cart.reduce((sum, item) => sum + item.price, 0);
-  document.querySelector('#total').textContent = total.toFixed(2);
-}
+      <p className="description">{lead.description}</p>
 
-function removeFromCart(index) {
-  cart.splice(index, 1);
-  renderCart();
-}
+      {isAcceptedTab && (
+        <div className="lead-meta">
+          <MetaItem label="Telefone" value={lead.contactPhoneNumber || 'Não informado'} icon="fa-phone" />
+          <MetaItem label="Email" value={lead.contactEmail || 'Não informado'} icon="fa-envelope" />
+        </div>
+      )}
 
-function checkout() {
-  if (cart.length === 0) {
-    alert('Carrinho vazio!');
-    return;
-  }
-  alert('Pedido realizado!');
-  cart.length = 0;
-  renderCart();
-}
+      <div className="card-footer">
+        <span className="price">{formatPrice(lead.price)}</span>
+        {showActions && (
+          <div className="actions">
+            <button
+              className="accept"
+              disabled={isProcessing}
+              onClick={() => onAccept(lead.id)}
+            >
+              <i className="fa-solid fa-circle-check" /> Aceitar
+            </button>
+            <button
+              className="decline"
+              disabled={isProcessing}
+              onClick={() => onDecline(lead.id)}
+            >
+              <i className="fa-solid fa-circle-xmark" /> Recusar
+            </button>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+};
 
-document.addEventListener('DOMContentLoaded', function() {
-  renderMenu();
-  renderCart();
-});
+const LeadManagementApp = () => {
+  const [activeTab, setActiveTab] = useState('Invited');
+  const [leads, setLeads] = useState({ Invited: [], Accepted: [] });
+  const [loadedTabs, setLoadedTabs] = useState({ Invited: false, Accepted: false });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [actionState, setActionState] = useState(null);
+
+  const fetchLeads = async (status) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.get(`${API_BASE_URL}/leads`, { params: { status } });
+      setLeads((prev) => ({ ...prev, [status]: response.data }));
+      setLoadedTabs((prev) => ({ ...prev, [status]: true }));
+    } catch (err) {
+      console.error(err);
+      setError('Não foi possível carregar os leads. Verifique se a API está em execução.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isTabLoaded = loadedTabs[activeTab];
+
+  useEffect(() => {
+    if (!isTabLoaded) {
+      fetchLeads(activeTab);
+    }
+  }, [activeTab, isTabLoaded]);
+
+  const handleAction = async (leadId, action) => {
+    setActionState({ leadId, action });
+    setError(null);
+
+    try {
+      const response = await axios.post(`${API_BASE_URL}/leads/${leadId}/${action}`);
+      const updatedLead = response.data;
+
+      setLeads((prev) => {
+        const next = {
+          Invited: [...prev.Invited],
+          Accepted: [...prev.Accepted]
+        };
+
+        if (action === 'accept') {
+          next.Invited = next.Invited.filter((lead) => lead.id !== leadId);
+          const withoutLead = next.Accepted.filter((lead) => lead.id !== leadId);
+          next.Accepted = [updatedLead, ...withoutLead];
+        } else {
+          next.Invited = next.Invited.filter((lead) => lead.id !== leadId);
+        }
+
+        return next;
+      });
+    } catch (err) {
+      console.error(err);
+      setError('Não foi possível atualizar o lead. Tente novamente.');
+    } finally {
+      setActionState(null);
+    }
+  };
+
+  const handleAccept = (leadId) => handleAction(leadId, 'accept');
+  const handleDecline = (leadId) => handleAction(leadId, 'decline');
+
+  const displayedLeads = leads[activeTab] ?? [];
+
+  return (
+    <>
+      <header>
+        <div>
+          <h1>Lead Manager</h1>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            Controle centralizado dos leads da sua equipe de vendas.
+          </p>
+        </div>
+        <i className="fa-solid fa-users-viewfinder" style={{ fontSize: '2rem', color: 'var(--primary)' }} />
+      </header>
+      <main className="container">
+        {error && <div className="error-message">{error}</div>}
+
+        <nav className="tabs" aria-label="Navegação de status">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              className={`tab-button ${tab.key === activeTab ? 'active' : ''}`}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              <i className={`fa-solid ${tab.icon}`} style={{ marginRight: '8px' }} />
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+
+        <p style={{ marginTop: '-0.5rem', marginBottom: '1.5rem', color: 'var(--muted)' }}>
+          {TABS.find((tab) => tab.key === activeTab)?.description}
+        </p>
+
+        {loading ? (
+          <div className="loading">
+            <i className="fa-solid fa-spinner fa-spin" style={{ marginRight: '8px' }} />
+            Carregando leads...
+          </div>
+        ) : displayedLeads.length === 0 ? (
+          <div className="empty-state">
+            <i className="fa-solid fa-inbox" style={{ fontSize: '2rem', marginBottom: '1rem' }} />
+            <p>Nenhum lead encontrado para este status.</p>
+          </div>
+        ) : (
+          <section className="leads-grid">
+            {displayedLeads.map((lead) => (
+              <LeadCard
+                key={lead.id}
+                lead={lead}
+                onAccept={handleAccept}
+                onDecline={handleDecline}
+                isProcessing={actionState?.leadId === lead.id}
+                showActions={activeTab === 'Invited'}
+                isAcceptedTab={activeTab === 'Accepted'}
+              />
+            ))}
+          </section>
+        )}
+      </main>
+    </>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<LeadManagementApp />);


### PR DESCRIPTION
## Summary
- replace the previous static demo with a React single-page lead management experience
- add a .NET 6 Web API backed by Entity Framework Core to list, accept, decline and seed leads while logging acceptance notifications
- cover the acceptance and decline flows with unit tests and document how to run the stack locally

## Testing
- `dotnet test` *(fails in the container because the .NET SDK is not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915142d05b0833382bd8c8b44893525)